### PR TITLE
Fix query parameter parsing and equality.

### DIFF
--- a/src/main/kotlin/tech/pronghorn/http/protocol/HttpUrl.kt
+++ b/src/main/kotlin/tech/pronghorn/http/protocol/HttpUrl.kt
@@ -24,6 +24,20 @@ data class QueryParam(val name: ByteArray,
                       val value: ByteArray) {
     constructor(name: String,
                 value: String) : this(name.toByteArray(Charsets.US_ASCII), value.toByteArray(Charsets.US_ASCII))
+
+    override fun equals(other: Any?): Boolean {
+        return when (other) {
+            this === other -> true
+            is QueryParam -> {
+                return Arrays.equals(name, other.name) && Arrays.equals(value, other.name)
+            }
+            else -> false
+        }
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash(name, value)
+    }
 }
 
 sealed class HttpUrlParseResult
@@ -123,8 +137,8 @@ class ByteArrayHttpUrl(private val path: ByteArray?,
             }
             else if(byte == ampersandByte){
                 if(valueStart != -1){
-                    val name = Arrays.copyOfRange(queryParams, nameStart, valueStart - nameStart - 1)
-                    val value = Arrays.copyOfRange(queryParams, valueStart, x - valueStart)
+                    val name = Arrays.copyOfRange(queryParams, nameStart, valueStart - 1)
+                    val value = Arrays.copyOfRange(queryParams, valueStart, x)
                     params.add(QueryParam(name, value))
                 }
                 nameStart = x + 1
@@ -134,8 +148,8 @@ class ByteArrayHttpUrl(private val path: ByteArray?,
         }
 
         if(valueStart != -1){
-            val name = Arrays.copyOfRange(queryParams, nameStart, valueStart - nameStart - 1)
-            val value = Arrays.copyOfRange(queryParams, valueStart, x - valueStart)
+            val name = Arrays.copyOfRange(queryParams, nameStart, valueStart - 1)
+            val value = Arrays.copyOfRange(queryParams, valueStart, x)
             params.add(QueryParam(name, value))
         }
 

--- a/src/test/kotlin/tech/pronghorn/http/HttpUrlParseTests.kt
+++ b/src/test/kotlin/tech/pronghorn/http/HttpUrlParseTests.kt
@@ -191,6 +191,19 @@ class HttpUrlParseTests : PronghornTest() {
         test.execute()
     }
 
+    @Test
+    fun urlParseTest12() {
+        val test = ParseTest(
+                "/foo?bar=5&baz=potato&buzz=bingo",
+                ValueHttpUrl(path = "/foo", queryParams = listOf(
+                        QueryParam("bar", "5"),
+                        QueryParam("baz", "potato"),
+                        QueryParam("buzz", "bingo")
+                ))
+        )
+        test.execute()
+    }
+
     // TODO: punycode test
 
     // TODO: percent encoding test


### PR DESCRIPTION
`HttpUrlParseTests.{urlParseTest10, urlParseTest11}` were failing, this should fix.

`QueryParam.equals` is overridden to handle Array equality.