### PR TITLE
Fix content-length string to int converstion

### DIFF
--- a/src/main/kotlin/tech/pronghorn/http/protocol/HttpRequestParser.kt
+++ b/src/main/kotlin/tech/pronghorn/http/protocol/HttpRequestParser.kt
@@ -165,7 +165,7 @@ public fun parseHttpRequest(buffer: ByteBuffer,
             var v = 0
             while (v < headerValue.size) {
                 contentLength *= 10
-                contentLength += headerValue[v]
+                contentLength += headerValue[v] - 48
                 v += 1
             }
         }


### PR DESCRIPTION
The current implementation is converting ASCII numbers to int... but its wrong as it does not subtract the value of the ascii character 0 which is 48dec.